### PR TITLE
Fix typo in head.php comment

### DIFF
--- a/head.php
+++ b/head.php
@@ -17,7 +17,7 @@
         href="https://fonts.googleapis.com/css?family=Nunito:200,200i,300,300i,400,400i,600,600i,700,700i,800,800i,900,900i"
         rel="stylesheet">
 
-    <!-- CSS perzonalizado para esta plantilla-->
+    <!-- CSS personalizado para esta plantilla-->
     <link href="css/sb-admin-2.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.datatables.net/2.0.7/css/dataTables.dataTables.css" />
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script> 


### PR DESCRIPTION
## Summary
- correct typo in head.php comment

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6840ee53afa4832196d448475f7d58c4